### PR TITLE
Backport ObjectID fix for UV-CDAT

### DIFF
--- a/Web/Core/vtkObjectIdMap.cxx
+++ b/Web/Core/vtkObjectIdMap.cxx
@@ -119,12 +119,6 @@ struct ObjectId
        return (this->GlobalId < other.GlobalId);
        }
 
-     if( this->Object.GetPointer() != NULL && other.Object.GetPointer() != NULL
-         && this->Object.GetPointer() != other.Object.GetPointer())
-       {
-       return (this->Object.GetPointer() < other.Object.GetPointer());
-       }
-
      return false;
    }
 


### PR DESCRIPTION
@aashish24 I'm not sure about the procedure to change the VTK head, but this would be nice to get into UV-CDAT.

Comparing pointer like this that points to different instances
could result in unspecified behavior.

Change-Id: I4973d9b44f85f2516cae03e2eb5b50ca924071da
