### PR TITLE
Fix timers in QT

### DIFF
--- a/Wrapping/Python/vtk/qt4/QVTKRenderWindowInteractor.py
+++ b/Wrapping/Python/vtk/qt4/QVTKRenderWindowInteractor.py
@@ -188,11 +188,6 @@ class QVTKRenderWindowInteractor(QtGui.QWidget):
 
         self._timers = {}
 
-        """
-        self._Timer = QtCore.QTimer(self)
-        self.connect(self._Timer, QtCore.SIGNAL('timeout()'), self.TimerEvent)
-        """
-
         self._Iren.AddObserver('CreateTimerEvent', self.CreateTimer)
         self._Iren.AddObserver('DestroyTimerEvent', self.DestroyTimer)
         self._Iren.GetRenderWindow().AddObserver('CursorChangedEvent',


### PR DESCRIPTION
Timers in QT are currently being handled by having a single `QTimer` that will only ever go off at 10ms intervals, and any call to `DestroyTimer()` will stop all future timer events until another `CreateTimer()` call is made. This fixes that by storing a timer for every call to `CreateTimer`, and destroying them individually as requested.
