### PR TITLE
Contour labels precision

### DIFF
--- a/Rendering/Core/vtkLabeledContourMapper.cxx
+++ b/Rendering/Core/vtkLabeledContourMapper.cxx
@@ -603,6 +603,7 @@ bool vtkLabeledContourMapper::PrepareRender(vtkRenderer *ren, vtkActor *act)
       continue;
       }
     metric.Value = scalars->GetComponent(ids[0], 0);
+    metric.Value = std::fabs(metric.Value) > 1e-6 ? metric.Value : 0.0;
     std::ostringstream str;
     str << metric.Value;
     metric.Text = str.str();


### PR DESCRIPTION
Clamp value to 0.0 if it is too small
